### PR TITLE
envsubst 命令不存在时报错退出

### DIFF
--- a/dataease/install.sh
+++ b/dataease/install.sh
@@ -146,7 +146,7 @@ cd ${templates_folder}
 templates_files=( dataease.properties mysql.env )
 for i in ${templates_files[@]}; do
    if [ -f $i ]; then
-      envsubst < $i > $conf_folder/$i
+      envsubst < $i > $conf_folder/$i  > /dev/null || exit 1
    fi
 done
 


### PR DESCRIPTION
避免`dectl reload` 很长时间，最后仍然失败