### PR TITLE
调整安装脚本磁盘空间检测逻辑

### DIFF
--- a/dataease/install.sh
+++ b/dataease/install.sh
@@ -33,13 +33,6 @@ else
 fi
 set +a
 
-read available_disk <<< $(df -H --output=avail ${DE_BASE} | tail -1)
-available_disk=${available_disk%?}
-available_disk=${available_disk%.*}
-if [[ $available_disk -lt 20 ]];then
-   log "\033[31m[警告] DataEase 运行目录所在磁盘剩余空间不足 20G 可能无法正常启动!\033[0m"
-fi
-
 DE_RUN_BASE=$DE_BASE/dataease
 conf_folder=${DE_RUN_BASE}/conf
 templates_folder=${DE_RUN_BASE}/templates
@@ -137,6 +130,13 @@ if [[ -f ${DE_RUN_BASE}/docker-compose-doris.yml ]]; then
 fi
 
 mkdir -p ${DE_RUN_BASE}
+
+
+read available_disk <<< $(df -m --output=avail ${DE_RUN_BASE} | tail -1)
+if [[ $available_disk -lt 20480 ]];then
+   log "\033[31m[警告] DataEase 运行目录所在磁盘剩余空间不足 20G 可能无法正常启动!\033[0m"
+fi
+
 cp -r ./dataease/* ${DE_RUN_BASE}/
 
 cd $DE_RUN_BASE


### PR DESCRIPTION
1. 当用户指定的安装目录在系统中不存在时，df -H --output=avail ${DE_BASE} 无法获取到该目录的空间大小，安装则会提示“...运行目录所在磁盘剩余空间不足 20G...”;
现将检测动作放到创建目录之后，则 df -H --output=avail ${DE_RUN_BASE} 可检测到已创建的安装目录空间大小，避免出现 “不足 20G” 报错提示。

2. 另外，如果磁盘空间在 TB 级，使用 df -H  然后去掉单位的数值与 20 做对比，也会提示 “不足 20G” ，现修改代码使用 df -m 以 MB 为单位进行对比，可完美避免报错。